### PR TITLE
Replaced the in Symfony 4.2 deprecated base controller class

### DIFF
--- a/Controller/SupervisorController.php
+++ b/Controller/SupervisorController.php
@@ -2,25 +2,35 @@
 
 namespace YZ\SupervisorBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
+use YZ\SupervisorBundle\Manager\SupervisorManager;
 
 /**
  * SupervisorController
  */
-class SupervisorController extends Controller
+class SupervisorController extends AbstractController
 {
     private static $publicInformations = ['description', 'group', 'name', 'state', 'statename'];
+
+    private $supervisorManager;
+    private $translator;
+
+    public function __construct(SupervisorManager $supervisorManager, TranslatorInterface $translator)
+    {
+        $this->supervisorManager = $supervisorManager;
+        $this->translator = $translator;
+    }
+
     /**
      * indexAction
      */
     public function indexAction()
     {
-        $supervisorManager = $this->get('supervisor.manager');
-
         return $this->render('YZSupervisorBundle:Supervisor:list.html.twig', array(
-            'supervisors' => $supervisorManager->getSupervisors(),
+            'supervisors' => $this->supervisorManager->getSupervisors(),
         ));
     }
 
@@ -38,7 +48,7 @@ class SupervisorController extends Controller
      */
     public function startStopProcessAction($start, $key, $name, $group, Request $request)
     {
-        $supervisor = $this->get('supervisor.manager')->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
 
         if (!$supervisor) {
             throw new \Exception('Supervisor not found');
@@ -59,14 +69,14 @@ class SupervisorController extends Controller
             $success = false;
             $this->get('session')->getFlashBag()->add(
                 'error',
-                $this->get('translator')->trans('process.stop.error', array(), 'YZSupervisorBundle')
+                $this->translator->trans('process.stop.error', array(), 'YZSupervisorBundle')
             );
         }
 
         if (!$success) {
             $this->get('session')->getFlashBag()->add(
                 'error',
-                $this->get('translator')->trans(
+                $this->translator->trans(
                     ($start == "1" ? 'process.start.error' : 'process.stop.error'),
                     array(),
                     'YZSupervisorBundle'
@@ -102,7 +112,7 @@ class SupervisorController extends Controller
      */
     public function startStopAllProcessesAction(Request $request, $start, $key)
     {
-        $supervisor = $this->get('supervisor.manager')->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
 
         if (!$supervisor) {
             throw new \Exception('Supervisor not found');
@@ -136,8 +146,7 @@ class SupervisorController extends Controller
      */
     public function showSupervisorLogAction($key)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
 
         if (!$supervisor) {
             throw new \Exception('Supervisor not found');
@@ -157,8 +166,7 @@ class SupervisorController extends Controller
      */
     public function clearSupervisorLogAction($key)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
 
         if (!$supervisor) {
             throw new \Exception('Supervisor not found');
@@ -167,7 +175,7 @@ class SupervisorController extends Controller
         if ($supervisor->clearLog() !== true) {
             $this->get('session')->getFlashBag()->add(
                 'error',
-                $this->get('translator')->trans('logs.delete.error', array(), 'YZSupervisorBundle')
+                $this->translator->trans('logs.delete.error', array(), 'YZSupervisorBundle')
             );
         }
 
@@ -183,8 +191,7 @@ class SupervisorController extends Controller
      */
     public function showProcessLogAction($key, $name, $group)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
         $process = $supervisor->getProcessByNameAndGroup($name, $group);
 
         if (!$supervisor) {
@@ -208,8 +215,7 @@ class SupervisorController extends Controller
      */
     public function showProcessLogErrAction($key, $name, $group)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
         $process = $supervisor->getProcessByNameAndGroup($name, $group);
 
         if (!$supervisor) {
@@ -233,8 +239,7 @@ class SupervisorController extends Controller
      */
     public function clearProcessLogAction($key, $name, $group)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
         $process = $supervisor->getProcessByNameAndGroup($name, $group);
 
         if (!$supervisor) {
@@ -244,7 +249,7 @@ class SupervisorController extends Controller
         if ($process->clearProcessLogs() !== true) {
             $this->get('session')->getFlashBag()->add(
                 'error',
-                $this->get('translator')->trans('logs.delete.error', array(), 'YZSupervisorBundle')
+                $this->translator->trans('logs.delete.error', array(), 'YZSupervisorBundle')
             );
         }
 
@@ -264,8 +269,7 @@ class SupervisorController extends Controller
      */
     public function showProcessInfoAction($key, $name, $group, Request $request)
     {
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
         $process = $supervisor->getProcessByNameAndGroup($name, $group);
 
         if (!$supervisor) {
@@ -317,8 +321,7 @@ class SupervisorController extends Controller
             throw new \Exception('Ajax request expected here');
         }
 
-        $supervisorManager = $this->get('supervisor.manager');
-        $supervisor = $supervisorManager->getSupervisorByKey($key);
+        $supervisor = $this->supervisorManager->getSupervisorByKey($key);
 
         if (!$supervisor) {
             throw new \Exception('Supervisor not found');

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="YZ\SupervisorBundle\Controller\SupervisorController" autowire="true" autoconfigure="true" public="false" />
         <service id="supervisor.manager" class="YZ\SupervisorBundle\Manager\SupervisorManager">
             <argument>%supervisor.servers%</argument>
         </service>


### PR DESCRIPTION
In Symfony 4.2 the base controller class is deprecated in favour of a simpler AbstractController. (https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-base-controller-class) This PR extends this new class and defines the controller as a service and injects any services that are not locatable in the service container.